### PR TITLE
Fix Railway Railpack deployment configuration

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -8,21 +8,62 @@
     "frontend/",
     "android/",
     "node_modules/",
-    ".git/"
+    ".git/",
+    "*.pyc",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".coverage",
+    "*.log",
+    ".env",
+    ".venv/",
+    "venv/",
+    "docs/",
+    "tests/",
+    "*.md"
   ],
   "steps": {
     "install": {
       "commands": [
-        "pip install --upgrade pip",
-        "cd backend/api && pip install -r requirements.txt"
-      ]
+        "pip install --upgrade pip setuptools wheel",
+        "cd backend/api && pip install --no-cache-dir -r requirements.txt"
+      ],
+      "timeout": 600
+    },
+    "build": {
+      "commands": [
+        "cd backend/api && python -m py_compile src/main.py",
+        "cd backend/api && python -c 'import src.main; print(\"✅ Flask app imports successfully\")'"
+      ],
+      "timeout": 120
     }
   },
   "deploy": {
-    "startCommand": "cd backend/api && gunicorn src.main:app --bind 0.0.0.0:${PORT:-5000} --workers 4 --timeout 120 --log-level info",
+    "startCommand": "cd backend/api && gunicorn src.main:app --bind 0.0.0.0:${PORT:-5000} --workers 4 --worker-class sync --timeout 120 --keep-alive 2 --max-requests 1000 --max-requests-jitter 100 --log-level info --access-logfile - --error-logfile -",
     "healthCheckPath": "/api/health",
     "healthCheckTimeout": 300,
+    "healthCheckInterval": 30,
+    "healthCheckRetries": 3,
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 3
+    "restartPolicyMaxRetries": 3,
+    "gracefulShutdownTimeout": 30
+  },
+  "environment": {
+    "PYTHONPATH": "/app/backend/api",
+    "PYTHONUNBUFFERED": "1",
+    "FLASK_ENV": "production",
+    "GUNICORN_CMD_ARGS": "--preload"
+  },
+  "resources": {
+    "memory": "512Mi",
+    "cpu": "500m"
+  },
+  "validation": {
+    "required_files": [
+      "backend/api/src/main.py",
+      "backend/api/requirements.txt"
+    ],
+    "required_env_vars": [
+      "PORT"
+    ]
   }
 }

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "echo 'Using Railpack for build process'",
+    "watchPatterns": [
+      "backend/api/**/*.py",
+      "backend/api/requirements.txt",
+      "railpack.json",
+      "backend/api/railpack.json"
+    ]
+  },
+  "deploy": {
+    "startCommand": "cd backend/api && gunicorn src.main:app --bind 0.0.0.0:$PORT --workers 4 --timeout 120 --log-level info",
+    "healthcheckPath": "/api/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  },
+  "environments": {
+    "production": {
+      "variables": {
+        "FLASK_ENV": "production",
+        "PYTHONUNBUFFERED": "1",
+        "GUNICORN_CMD_ARGS": "--preload"
+      }
+    },
+    "staging": {
+      "variables": {
+        "FLASK_ENV": "staging",
+        "PYTHONUNBUFFERED": "1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Optimized root railpack.json with enhanced schema and build validation
- Restored backend/api/railpack.json for service-level deployment  
- Added railway.json for platform-specific deployment settings
- Created comprehensive deployment runbook with troubleshooting
- Added ops_report.json with detailed deployment strategy and rollback plans

Fixes: Railway 'Cannot create code snapshot' error
Health endpoint: /api/health verified and configured
Resource limits: 512Mi memory, 500m CPU, 4 workers